### PR TITLE
Fix dtype error in default arguments to add_mesh()

### DIFF
--- a/pyviz3d/visualizer.py
+++ b/pyviz3d/visualizer.py
@@ -251,7 +251,7 @@ blender_tools.main()")
                  name: str,
                  path: str,
                  translation: np.array=np.array([0.0, 0.0, 0.0]),
-                 rotation: np.array=np.array([0, 0, 0, 1]),
+                 rotation: np.array=np.array([0.0, 0.0, 0.0, 1.0]),
                  scale: np.array=np.array([1, 1, 1]),
                  color: np.array=np.array([255, 255, 255]),
                  visible: bool=True):


### PR DESCRIPTION
Converted literals from ints to floats to avoid int64 instead of float64) for default argument to fix

```
numpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'divide' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```

during quaternion normalization