### PR TITLE
Fix/mesh and color bugs

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,4 +37,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        # pytest exits 5 when no tests are collected; treat that as success
+        # so CI passes on a tests-empty repo. Real failures (1, 2, 3, 4) still fail.
+        pytest || ([ $? = 5 ] && exit 0)

--- a/pyviz3d/mesh.py
+++ b/pyviz3d/mesh.py
@@ -18,8 +18,9 @@ class Mesh:
         """
         self.filename_source = filename
         mesh_file = os.path.split(filename)[-1]
-        mesh_file_name = mesh_file.split('.')[0]
-        self.mesh_file_extension = mesh_file.split('.')[1]
+        # splitext handles names like 'mesh_aligned_0.05.ply' → ('mesh_aligned_0.05', '.ply')
+        mesh_file_name, ext = os.path.splitext(mesh_file)
+        self.mesh_file_extension = ext.lstrip('.')
         mesh_file_size = os.path.getsize(filename)
         self.filename_destination = mesh_file_name + '_' + str(mesh_file_size) + '.' + self.mesh_file_extension
         self.translation = translation.tolist()
@@ -52,7 +53,10 @@ class Mesh:
         """Copy the mesh file into the destination directory."""
         destination_dir = os.path.dirname(path)
         destination_path = os.path.join(destination_dir, self.filename_destination)
-        if not os.path.exists(self.filename_destination):
+        # Cache by checking the actual destination path, not the basename
+        # (which would resolve relative to cwd and silently skip the copy
+        # if a same-named file happened to exist there).
+        if not os.path.exists(destination_path):
             copyfile(self.filename_source, destination_path)
 
     def write_blender(self, path):

--- a/pyviz3d/mesh.py
+++ b/pyviz3d/mesh.py
@@ -20,6 +20,8 @@ class Mesh:
         mesh_file = os.path.split(filename)[-1]
         # splitext handles names like 'mesh_aligned_0.05.ply' → ('mesh_aligned_0.05', '.ply')
         mesh_file_name, ext = os.path.splitext(mesh_file)
+        if not ext:
+            raise ValueError("Mesh filename must include a supported file extension: %r" % filename)
         self.mesh_file_extension = ext.lstrip('.')
         mesh_file_size = os.path.getsize(filename)
         self.filename_destination = mesh_file_name + '_' + str(mesh_file_size) + '.' + self.mesh_file_extension

--- a/pyviz3d/src/js/scene.js
+++ b/pyviz3d/src/js/scene.js
@@ -209,7 +209,7 @@ function get_mesh(properties){
 		} else {  // ply
 			const materialShader = (geometry.hasAttribute('normal')) ? THREE.MeshPhongMaterial : THREE.MeshBasicMaterial
 			const material = new materialShader({vertexColors: geometry.hasAttribute('color')})
-			if (!geometry.hasAttribute){
+			if (!geometry.hasAttribute('color')){
 				material.color.set(new THREE.Color(colorString));
 			}
 			object = new THREE.Mesh(geometry, material);


### PR DESCRIPTION
Three small bug fixes plus a CI tweak.

  - **`pyviz3d/mesh.py` extension parsing**: filenames like `mesh_aligned_0.05.ply` were parsed as extension `05`. Use `os.path.splitext` so the destination keeps the correct `.ply` suffix.
  - **`pyviz3d/mesh.py` cache check uses wrong path**: `write_binary` checked `os.path.exists(self.filename_destination)` against the bare basename, which resolves relative to cwd. The mesh would be silently skipped or always re-copied depending on the user's cwd. Now checks the actual `destination_path`.
  - **`pyviz3d/src/js/scene.js` missing argument**: `if (!geometry.hasAttribute) { ... }` is always falsy because `hasAttribute` (no parens) is a function reference. The user-supplied solid colour was therefore never applied to PLYs without per-vertex colours. Added the missing `'color'` argument.
  - **CI tolerate empty test suite**: the workflow ran `pytest` with no tests in the repo, which exits with code 5 ("no tests collected") and fails CI on every push. Treat exit 5 as success.